### PR TITLE
Minimal Python 2/3 compatibility.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,11 @@
 '''
-Reference implementation of node2vec. 
+Reference implementation of node2vec.
 
 Author: Aditya Grover
 
 For more details, refer to the paper:
 node2vec: Scalable Feature Learning for Networks
-Aditya Grover and Jure Leskovec 
+Aditya Grover and Jure Leskovec
 Knowledge Discovery and Data Mining (KDD), 2016
 '''
 
@@ -83,10 +83,10 @@ def learn_embeddings(walks):
 	'''
 	Learn embeddings by optimizing the Skipgram objective using SGD.
 	'''
-	walks = [map(str, walk) for walk in walks]
+	walks = [list(map(str, walk)) for walk in walks]
 	model = Word2Vec(walks, size=args.dimensions, window=args.window_size, min_count=0, sg=1, workers=args.workers, iter=args.iter)
-	model.save_word2vec_format(args.output)
-	
+	model.wv.save_word2vec_format(args.output)
+
 	return
 
 def main(args):

--- a/src/node2vec.py
+++ b/src/node2vec.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 import networkx as nx
 import random
@@ -28,7 +30,7 @@ class Graph():
 					walk.append(cur_nbrs[alias_draw(alias_nodes[cur][0], alias_nodes[cur][1])])
 				else:
 					prev = walk[-2]
-					next = cur_nbrs[alias_draw(alias_edges[(prev, cur)][0], 
+					next = cur_nbrs[alias_draw(alias_edges[(prev, cur)][0],
 						alias_edges[(prev, cur)][1])]
 					walk.append(next)
 			else:
@@ -43,9 +45,9 @@ class Graph():
 		G = self.G
 		walks = []
 		nodes = list(G.nodes())
-		print 'Walk iteration:'
+		print('Walk iteration:')
 		for walk_iter in range(num_walks):
-			print str(walk_iter+1), '/', str(num_walks)
+			print(str(walk_iter+1), '/', str(num_walks))
 			random.shuffle(nodes)
 			for node in nodes:
 				walks.append(self.node2vec_walk(walk_length=walk_length, start_node=node))


### PR DESCRIPTION
* Import `print_function` from `__future__`
* Cast iterator returned my `map` to `list`
* Resolve `gensim` deprecation warnings regarding use of `save_word2vec_format`

The rest of the diff is from removal of trailing whitespace on a few lines, and a missing newline at the end of `src/node2vec.py`.