### PR TITLE
bug fix: model.save_word2vec_format is deprecated

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,7 @@ def learn_embeddings(walks):
 	'''
 	walks = [map(str, walk) for walk in walks]
 	model = Word2Vec(walks, size=args.dimensions, window=args.window_size, min_count=0, sg=1, workers=args.workers, iter=args.iter)
-	model.save_word2vec_format(args.output)
+	model.wv.save_word2vec_format(args.output)
 	
 	return
 


### PR DESCRIPTION
The line "model.save_word2vec_format(args.output)" causes the following exception from within gensim: "DeprecationWarning: Deprecated. Use model.wv.save_word2vec_format instead."
This PR fixes this bug.