### PR TITLE
Update requirements to run in 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 networkx==1.11
 numpy==1.11.2
 gensim==0.13.3
+smart-open==1.2.1


### PR DESCRIPTION
Smart-open needs to be in this version for it to run.