### PR TITLE
Change args passed to Word2Vec class

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,7 @@ def parse_args():
 	parser.add_argument('--window-size', type=int, default=10,
                     	help='Context size for optimization. Default is 10.')
 
-	parser.add_argument('--iter', default=1, type=int,
+	parser.add_argument('--epochs', default=1, type=int,
                       help='Number of epochs in SGD')
 
 	parser.add_argument('--workers', type=int, default=8,
@@ -84,7 +84,7 @@ def learn_embeddings(walks):
 	Learn embeddings by optimizing the Skipgram objective using SGD.
 	'''
 	walks = [map(str, walk) for walk in walks]
-	model = Word2Vec(walks, size=args.dimensions, window=args.window_size, min_count=0, sg=1, workers=args.workers, iter=args.iter)
+	model = Word2Vec(walks, vector_size=args.dimensions, window=args.window_size, min_count=0, sg=1, workers=args.workers, epochs=args.epochs)
 	model.save_word2vec_format(args.output)
 	
 	return


### PR DESCRIPTION
The args "size" and "iter" (line 87, in the script "src/main.py") are no longer used in Gensim.4.0 (see https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4), which throws an error, so I changed them to "vector_size" and "epochs", respectively.